### PR TITLE
Link in package.json description points to github

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloc",
   "version": "0.0.0-development",
-  "description": "An npm module for distributing cloc by Al Danial http://cloc.sourceforge.net/",
+  "description": "An npm module for distributing cloc by Al Danial https://github.com/AlDanial/cloc",
   "main": "lib/cloc",
   "scripts": {
     "test": "echo \"Error: no test specified\"",


### PR DESCRIPTION
According to http://cloc.sourceforge.net/ the project has moved to github.
Reflecting this in the `description` field of `package.json`.